### PR TITLE
Log the X-Request-Id header as transaction_id.

### DIFF
--- a/config-local.yml
+++ b/config-local.yml
@@ -24,11 +24,11 @@ server:
         port: 14181
 
   requestLog:
-
     appenders:
 
       - type: console
-
+        # Add transaction_id to the end of Dropwizard's default format, which is itself based on the "combined" log format
+        logFormat: "%h %l %u [%t] \"%r\" %s %b \"%i{Referer}\" \"%i{User-Agent}\" %D transaction_id=%i{X-Request-Id}"
         # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
         timeZone: UTC
 

--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,8 @@ server:
     appenders:
 
       - type: console
-
+        # Add transaction_id to the end of Dropwizard's default format, which is itself based on the "combined" log format
+        logFormat: "%h %l %u [%t] \"%r\" %s %b \"%i{Referer}\" \"%i{User-Agent}\" %D transaction_id=%i{X-Request-Id}"
         # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
         timeZone: UTC
 


### PR DESCRIPTION
Adding transaction_id to the end of the log line means we no longer rely
on being called by the ResilientClient (which embeds transaction_id in
its User-Agent string) in order to log cascaded transaction ids. This
format is parsable by the existing log filtering and forwarding
processes.