### PR TITLE
Mongo connection/timeout exception handling during initial startup.

### DIFF
--- a/src/main/java/com/ft/universalpublishing/documentstore/DocumentStoreApiApplication.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/DocumentStoreApiApplication.java
@@ -33,6 +33,7 @@ import com.ft.universalpublishing.documentstore.validators.UuidValidator;
 
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoTimeoutException;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoDatabase;
 
@@ -50,9 +51,12 @@ import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DocumentStoreApiApplication extends Application<DocumentStoreApiConfiguration> {
 
+    private static final Logger logger = LoggerFactory.getLogger(DocumentStoreApiApplication.class);
     public static void main(final String[] args) throws Exception {
         new DocumentStoreApiApplication().run(args);
     }
@@ -64,7 +68,7 @@ public class DocumentStoreApiApplication extends Application<DocumentStoreApiCon
     }
 
     @Override
-    public void run(final DocumentStoreApiConfiguration configuration, final Environment environment) throws Exception {
+    public void run(final DocumentStoreApiConfiguration configuration, final Environment environment) {
         List<String> transactionUrlPattern = new ArrayList<>(
                 Arrays.asList("/lists/*", "/content-query", "/content/*", "/internalcomponents/*", "/complementarycontent/*"));
         environment.servlets().addFilter("transactionIdFilter", new TransactionIdFilter())
@@ -76,10 +80,32 @@ public class DocumentStoreApiApplication extends Application<DocumentStoreApiCon
 
         environment.jersey().register(new BuildInfoResource());
 
-        final MongoClient mongoClient = getMongoClient(configuration.getMongo());
-        MongoDatabase database = mongoClient.getDatabase(configuration.getMongo().getDb());
+        MongoDatabase database = null;
+        MongoDocumentStoreService documentStoreService;
 
-        final MongoDocumentStoreService documentStoreService = new MongoDocumentStoreService(database);
+        try {
+            final MongoClient mongoClient = getMongoClient(configuration.getMongo());
+            database = mongoClient.getDatabase(configuration.getMongo().getDb());
+            documentStoreService = new MongoDocumentStoreService(database);
+
+            // this will fail and timeout if MongoClient fails to connect to any configured node initially
+            documentStoreService.applyIndexes();
+
+            logger.info("Registering app resources ...");
+            registerResources(configuration, environment, database, documentStoreService);
+        } catch (final MongoTimeoutException e) {
+            logger.error("Failed to connect to mongo database, check/fix the issues and restart the service.", e);
+        }
+
+        // We are registering health checks regardless, so that we can have proper visibility
+        registerHealthChecks(configuration, environment, database);
+
+
+
+    }
+
+
+    private void registerResources(DocumentStoreApiConfiguration configuration, Environment environment, MongoDatabase database, MongoDocumentStoreService documentStoreService) {
         final UuidValidator uuidValidator = new UuidValidator();
         final ContentListValidator contentListValidator = new ContentListValidator(uuidValidator);
 
@@ -145,9 +171,11 @@ public class DocumentStoreApiApplication extends Application<DocumentStoreApiCon
         environment.jersey().register(new DocumentQueryResource(documentStoreService, configuration.getApiHost()));
         environment.jersey().register(new DocumentIDResource(documentStoreService));
 
-        environment.healthChecks().register(configuration.getHealthcheckParameters().getName(), new DocumentStoreHealthCheck(database, configuration.getHealthcheckParameters()));
+    }
 
-        documentStoreService.applyIndexes();
+    private void registerHealthChecks(DocumentStoreApiConfiguration configuration, Environment environment, MongoDatabase database) {
+        environment.healthChecks().register(configuration.getHealthcheckParameters().getName(),
+                new DocumentStoreHealthCheck(database, configuration.getHealthcheckParameters()));
     }
 
     private MongoClient getMongoClient(MongoConfig config) {

--- a/src/main/java/com/ft/universalpublishing/documentstore/MongoConfig.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/MongoConfig.java
@@ -1,15 +1,14 @@
 package com.ft.universalpublishing.documentstore;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.mongodb.ServerAddress;
 import io.dropwizard.util.Duration;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,6 +34,9 @@ public class MongoConfig {
   @NotNull
   @JsonProperty
   private String db;
+
+  @JsonProperty
+  private Duration serverSelectorTimeout;
 
   private Duration idleTimeout;
 
@@ -113,5 +115,13 @@ public class MongoConfig {
             .add("db", db)
             .add("idleTimeout", idleTimeout)
             .toString();
+  }
+
+  public Duration getServerSelectorTimeout() {
+    return serverSelectorTimeout;
+  }
+
+  public void setServerSelectorTimeout(Duration serverSelectorTimeout) {
+    this.serverSelectorTimeout = serverSelectorTimeout;
   }
 }

--- a/src/main/java/com/ft/universalpublishing/documentstore/health/DocumentStoreHealthCheck.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/health/DocumentStoreHealthCheck.java
@@ -27,10 +27,6 @@ public class DocumentStoreHealthCheck extends AdvancedHealthCheck {
 
         final String message = "Cannot connect to MongoDB";
 
-        if (null == db) {
-            return AdvancedResult.error(this, message);
-        }
-
         try {
             Document commandResult = db.runCommand(Document.parse("{ serverStatus : 1 }"));
             boolean isOK = !commandResult.isEmpty();

--- a/src/main/java/com/ft/universalpublishing/documentstore/health/DocumentStoreHealthCheck.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/health/DocumentStoreHealthCheck.java
@@ -12,8 +12,8 @@ public class DocumentStoreHealthCheck extends AdvancedHealthCheck {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DocumentStoreHealthCheck.class);
 
-    private MongoDatabase db;
-    private HealthcheckParameters healthcheckParameters;
+    private final MongoDatabase db;
+    private final HealthcheckParameters healthcheckParameters;
 
 
     public DocumentStoreHealthCheck(MongoDatabase db, HealthcheckParameters healthcheckParameters) {
@@ -23,9 +23,13 @@ public class DocumentStoreHealthCheck extends AdvancedHealthCheck {
     }
 
     @Override
-    protected AdvancedResult checkAdvanced() throws Exception {
+    protected AdvancedResult checkAdvanced() {
 
         final String message = "Cannot connect to MongoDB";
+
+        if (null == db) {
+            return AdvancedResult.error(this, message);
+        }
 
         try {
             Document commandResult = db.runCommand(Document.parse("{ serverStatus : 1 }"));

--- a/src/main/java/com/ft/universalpublishing/documentstore/service/MongoDocumentStoreService.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/service/MongoDocumentStoreService.java
@@ -32,8 +32,10 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class MongoDocumentStoreService {

--- a/src/test/java/com/ft/universalpublishing/documentstore/DocumentStoreApiApplicationTest.java
+++ b/src/test/java/com/ft/universalpublishing/documentstore/DocumentStoreApiApplicationTest.java
@@ -1,0 +1,32 @@
+package com.ft.universalpublishing.documentstore;
+
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public class DocumentStoreApiApplicationTest {
+
+    @ClassRule
+    public static final DropwizardAppRule RULE =
+            new DropwizardAppRule<>(DocumentStoreApiApplication.class,
+                    ResourceHelpers.resourceFilePath("config-no-mongo-test.yml"));
+
+    @Test
+    public void applicationShouldRegisterHealthChecksEvenIfMongoConnectionFails() {
+        Client client = new JerseyClientBuilder().build();
+
+        Response response = client.target(
+                String.format("http://localhost:%d/__health", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+}

--- a/src/test/java/com/ft/universalpublishing/documentstore/DocumentStoreApiApplicationTest.java
+++ b/src/test/java/com/ft/universalpublishing/documentstore/DocumentStoreApiApplicationTest.java
@@ -1,5 +1,7 @@
 package com.ft.universalpublishing.documentstore;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.glassfish.jersey.client.JerseyClientBuilder;
@@ -8,6 +10,7 @@ import org.junit.Test;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -19,7 +22,7 @@ public class DocumentStoreApiApplicationTest {
                     ResourceHelpers.resourceFilePath("config-no-mongo-test.yml"));
 
     @Test
-    public void applicationShouldRegisterHealthChecksEvenIfMongoConnectionFails() {
+    public void applicationShouldRegisterHealthChecksEvenIfMongoConnectionFails() throws IOException {
         Client client = new JerseyClientBuilder().build();
 
         Response response = client.target(
@@ -27,6 +30,14 @@ public class DocumentStoreApiApplicationTest {
                 .request()
                 .get();
 
+
+        final String payload = response.readEntity(String.class);
+        final JsonNode jsonNode = new ObjectMapper().readValue(payload, JsonNode.class);
+
+        // being sure that the node/field is valid/present in the response, default asBoolean call always returns false.
+        final String ok = jsonNode.at("/checks/0/ok").asText();
+
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals("false", ok);
     }
 }

--- a/src/test/resources/config-no-mongo-test.yml
+++ b/src/test/resources/config-no-mongo-test.yml
@@ -1,0 +1,84 @@
+mongo:
+  hosts: ["localhost"]
+  port: 98765
+  db: upp-store
+  serverSelectorTimeout: 100ms
+  
+apiHost: localhost
+cacheTtl: 30
+
+healthcheckParameters:
+    name: "Connectivity to MongoDB"
+    severity: 1
+    businessImpact: "Editorially curated lists won't be available for use on Next."
+    technicalSummary: "Cannot connect to the MongoDB content store. This will result in failure to retrieve articles from the new content platform and affect a variety of products."
+    panicGuideUrl: "https://dewey.ft.com/document-store-api.html"
+
+server:
+
+  applicationConnectors:
+    - type: http
+      port: 14180
+
+  adminConnectors:
+      - type: http
+        port: 14181
+
+  requestLog:
+    appenders:
+
+      - type: console
+        # Add transaction_id to the end of Dropwizard's default format, which is itself based on the "combined" log format
+        logFormat: "%h %l %u [%t] \"%r\" %s %b \"%i{Referer}\" \"%i{User-Agent}\" %D transaction_id=%i{X-Request-Id}"
+        # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
+        timeZone: UTC
+
+      - type: file
+
+        # The file to which current statements will be logged.
+        currentLogFilename: /var/log/apps/document-store-api-dw-access.log
+
+        # When the log file rotates, the archived log will be renamed to this and gzipped. The
+        # %d is replaced with the previous day (yyyy-MM-dd). Custom rolling windows can be created
+        # by passing a SimpleDateFormat-compatible format as an argument: "%d{yyyy-MM-dd-hh}".
+        archivedLogFilenamePattern: /var/log/apps/document-store-api-dw-access-%d.log.gz
+
+        # The number of archived files to keep.
+        archivedFileCount: 6
+
+        # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
+        timeZone: UTC
+
+logging:
+
+  level: INFO
+
+  loggers:
+    io.dropwizard: DEBUG
+    com.ft.api.util.transactionid.TransactionIdFilter: WARN
+
+  appenders:
+
+    - type: console
+
+    - type: file
+      # Do not write log statements below this threshold to the file.
+      threshold: ALL
+
+      # The file to which current statements will be logged.
+      currentLogFilename: /var/log/apps/document-store-api-dw-app.log
+
+      # When the log file rotates, the archived log will be renamed to this and gzipped. The
+      # %d is replaced with the previous day (yyyy-MM-dd). Custom rolling windows can be created
+      # by passing a SimpleDateFormat-compatible format as an argument: "%d{yyyy-MM-dd-hh}".
+      archivedLogFilenamePattern: /var/log/apps/document-store-api-dw-app-%d.log.gz
+
+      # The number of archived files to keep.
+      archivedFileCount: 5
+
+      # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
+      timeZone: UTC
+      
+appInfo:
+    systemCode: "document-store-api"
+    description: "document-store-api" 

--- a/src/test/resources/config-no-mongo-test.yml
+++ b/src/test/resources/config-no-mongo-test.yml
@@ -56,6 +56,7 @@ logging:
   loggers:
     io.dropwizard: DEBUG
     com.ft.api.util.transactionid.TransactionIdFilter: WARN
+    com.ft.universalpublishing.documentstore: DEBUG
 
   appenders:
 


### PR DESCRIPTION
App now starts with at least health checks registered even if there is no connection to any mongo nodes. 

We still need to restart the app once the connection issue is resolved but now we can monitor it and be aware of its failure status, it's not going to be blocked forever during the startup.