### PR TITLE
Json variants instead of strict MediaType.APPLICATION_JSON annotation…

### DIFF
--- a/src/test/java/com/ft/universalpublishing/documentstore/resources/DocumentContentResourceEndpointTest.java
+++ b/src/test/java/com/ft/universalpublishing/documentstore/resources/DocumentContentResourceEndpointTest.java
@@ -1,6 +1,7 @@
 package com.ft.universalpublishing.documentstore.resources;
 
 import com.ft.api.jaxrs.errors.ErrorEntity;
+import com.ft.api.jaxrs.errors.WebApplicationClientException;
 import com.ft.universalpublishing.documentstore.exception.DocumentNotFoundException;
 import com.ft.universalpublishing.documentstore.exception.ExternalSystemUnavailableException;
 import com.ft.universalpublishing.documentstore.exception.ValidationException;
@@ -497,6 +498,19 @@ public class DocumentContentResourceEndpointTest {
             .post(Entity.json(null));
 
     assertThat("response", clientResponse, hasProperty("status", equalTo(405)));
+  }
+
+  @Test
+  public void contentTypeValidationShouldPassForJsonVariants() {
+    final DocumentResource resource = new DocumentResource(null);
+    resource.validateContentTypeForJsonVariant(Collections.singletonList("application/anything-is.possible+json; unknown=directive; version=1.0; charset=utf-8"));
+    resource.validateContentTypeForJsonVariant(Collections.singletonList("application/json; charset=utf-8; key=value"));
+  }
+
+  @Test(expected = WebApplicationClientException.class)
+  public void contentTypeValidationShouldFailForNonJsonVariants() {
+    final DocumentResource resource = new DocumentResource(null);
+    resource.validateContentTypeForJsonVariant(Collections.singletonList("application/octet-stream; unknown=directive; version=1.0; charset=utf-8"));
   }
 
   private Response writeDocument(String writePath, Document document) {


### PR DESCRIPTION
… on PUT - "/{collection}/{uuidString}"

I've added the test cases for content-type validation method but couldn't manage to get the jersey client to send a malformed content-type header for e2e testing. The client always override the previously set headers and it strictly depends on the Body's media type which has to be "application/json" in order to actually serialize the json body during a test request.