### PR TITLE
Fixes made for misleading MESSAGE = GET/POST/PUT/DELETE splunk logs

### DIFF
--- a/config-local.yml
+++ b/config-local.yml
@@ -37,59 +37,48 @@ server:
         logFormat: "%m%n"
         # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
         timeZone: UTC
-
       - type: file
-
         # The file to which current statements will be logged.
         currentLogFilename: /var/log/apps/document-store-api-dw-access.log
-
         # When the log file rotates, the archived log will be renamed to this and gzipped. The
         # %d is replaced with the previous day (yyyy-MM-dd). Custom rolling windows can be created
         # by passing a SimpleDateFormat-compatible format as an argument: "%d{yyyy-MM-dd-hh}".
         archivedLogFilenamePattern: /var/log/apps/document-store-api-dw-access-%d.log.gz
-
         # The number of archived files to keep.
         archivedFileCount: 6
-
         # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
         timeZone: UTC
 
 logging:
-
   level: INFO
-
   loggers:
+    io.dropwizard: WARN
     com.sun.jersey.spi.container.ContainerResponse: "OFF"
     org.openrdf.rio.helpers.ParseErrorLogger: "OFF"
-    io.dropwizard: WARN
     org.eclipse.jetty: "OFF"
-    javax.ws.rs.client: WARN
-    com.sun.jersey.api.client: WARN
-    ch.qos.logback: WARN
-    com.ft.api.util.transactionid.TransactionIdFilter: WARN
+    javax.ws.rs.client: "OFF"
+    com.sun.jersey.api.client: "OFF"
+    ch.qos.logback: "OFF"
+    com.ft.api.util.transactionid.TransactionIdFilter: "OFF"
     com.ft.platform.dropwizard.HealthCheckPageData: "OFF"
     com.ft.platform.dropwizard.metrics: "OFF"
     com.ft.api.jaxrs.errors: "OFF"
+    org.glassfish.jersey.client: "OFF"
 
   appenders:
-
     - type: console
-
+      logFormat: "%m%n"
     - type: file
       # Do not write log statements below this threshold to the file.
       threshold: ALL
-
       # The file to which current statements will be logged.
       currentLogFilename: /var/log/apps/document-store-api-dw-app.log
-
       # When the log file rotates, the archived log will be renamed to this and gzipped. The
       # %d is replaced with the previous day (yyyy-MM-dd). Custom rolling windows can be created
       # by passing a SimpleDateFormat-compatible format as an argument: "%d{yyyy-MM-dd-hh}".
       archivedLogFilenamePattern: /var/log/apps/document-store-api-dw-app-%d.log.gz
-
       # The number of archived files to keep.
       archivedFileCount: 5
-
       # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
       timeZone: UTC
       

--- a/config.yaml
+++ b/config.yaml
@@ -32,34 +32,26 @@ server:
         port: 14181
 
   requestLog:
-
-    appenders:
-      - type: console
-        # Add format needed for 'fluent-logging' library to make in JSON format
-        logFormat: "%m%n"
-        # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
-        timeZone: UTC
+    appenders: []
 
 logging:
-
   level: INFO
-
   loggers:
+    io.dropwizard: WARN
     com.sun.jersey.spi.container.ContainerResponse: "OFF"
     org.openrdf.rio.helpers.ParseErrorLogger: "OFF"
-    io.dropwizard: WARN
     org.eclipse.jetty: "OFF"
-    javax.ws.rs.client: WARN
-    com.sun.jersey.api.client: WARN
-    ch.qos.logback: WARN
-    com.ft.api.util.transactionid: ERROR
+    javax.ws.rs.client: "OFF"
+    com.sun.jersey.api.client: "OFF"
+    ch.qos.logback: "OFF"
+    com.ft.api.util.transactionid: "OFF"
     com.ft.platform.dropwizard.HealthCheckPageData: "OFF"
     com.ft.platform.dropwizard.metrics: "OFF"
     com.ft.api.jaxrs.errors: "OFF"
-
+    org.glassfish.jersey.client: "OFF"
   appenders:
-
     - type: console
+      logFormat: "%m%n"
 
 appInfo:
     systemCode: "document-store-api"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.Financial-Times</groupId>
     <artifactId>document-store-api</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.6</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -19,7 +19,7 @@
         <advanced-dropwizard-healthcheck.version>4.14.2</advanced-dropwizard-healthcheck.version>
         <jax-rs-build-info-resource.version>1.3.1</jax-rs-build-info-resource.version>
         <jaxrs.error-handling.version>1.1.4</jaxrs.error-handling.version>
-        <jax-rs.transaction-id-handling.version>2.6.8</jax-rs.transaction-id-handling.version>
+        <jax-rs.transaction-id-handling.version>2.6.9</jax-rs.transaction-id-handling.version>
         <jackson.date.serialization.version>0.1.29</jackson.date.serialization.version>
         <junit.version>4.11</junit.version>
         <mockito-core.version>1.9.5</mockito-core.version>

--- a/src/main/java/com/ft/universalpublishing/documentstore/handler/MultipleUuidValidationHandler.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/handler/MultipleUuidValidationHandler.java
@@ -11,6 +11,7 @@ import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.HOST;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.MESSAGE;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_GET;
 import static java.util.Collections.emptySet;
 import static javax.ws.rs.core.HttpHeaders.USER_AGENT;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
@@ -35,7 +36,7 @@ public class MultipleUuidValidationHandler implements Handler {
         Set<UUID> uuidValues = new LinkedHashSet<>();
         
         
-        logger.withMetodName("handle").withField(METHOD, context.getParameter(METHOD))
+        logger.withMetodName("handle").withField(METHOD, METHOD_GET)
                 .withField(HOST, context.getUriInfo().getAbsolutePath().getHost())
                 .withField(FluentLoggingUtils.USER_AGENT, context.getHttpHeaders().getHeaderString(USER_AGENT))
                 .withField(ACCEPT, APPLICATION_JSON_TYPE);

--- a/src/main/java/com/ft/universalpublishing/documentstore/resources/DocumentIDResource.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/resources/DocumentIDResource.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.CLIENT;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_GET;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.TRANSACTION_ID;
 import static javax.ws.rs.core.Response.ok;
 import static org.slf4j.MDC.get;
@@ -38,7 +39,7 @@ public class DocumentIDResource {
         new FluentLoggingWrapper().withClassName(this.getClass().getCanonicalName())
                 .withMetodName("getIDsForCollectionAndAuthority").withResponse(response)
                 .withTransactionId(get(TRANSACTION_ID)).withField(CLIENT, response.getClass().getCanonicalName())
-                .withField(METHOD, "GET")
+                .withField(METHOD, METHOD_GET)
                 .build().logInfo();
 
         return response;

--- a/src/main/java/com/ft/universalpublishing/documentstore/resources/DocumentQueryResource.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/resources/DocumentQueryResource.java
@@ -18,6 +18,7 @@ import javax.ws.rs.core.Response;
 import static com.ft.universalpublishing.documentstore.resources.DocumentResource.CHARSET_UTF_8;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.MESSAGE;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_GET;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.TRANSACTION_ID;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
@@ -49,7 +50,7 @@ public class DocumentQueryResource {
     public final Response findContentByIdentifier(@QueryParam("identifierAuthority") String authority,
             @QueryParam("identifierValue") String identifierValue) {
         Response response;
-        logger.withMetodName("findContentByIdentifier").withTransactionId(get(TRANSACTION_ID)).withField(METHOD, "GET");
+        logger.withMetodName("findContentByIdentifier").withTransactionId(get(TRANSACTION_ID)).withField(METHOD, METHOD_GET);
 
         if (isNullOrEmpty(authority) || isNullOrEmpty(identifierValue)) {
             response = status(SC_BAD_REQUEST).entity(singletonMap("message",

--- a/src/main/java/com/ft/universalpublishing/documentstore/resources/DocumentResource.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/resources/DocumentResource.java
@@ -6,12 +6,10 @@ import static com.ft.universalpublishing.documentstore.model.read.Operation.GET_
 import static com.ft.universalpublishing.documentstore.model.read.Operation.GET_FILTERED;
 import static com.ft.universalpublishing.documentstore.model.read.Operation.GET_MULTIPLE_FILTERED;
 import static com.ft.universalpublishing.documentstore.model.read.Operation.REMOVE;
-import static javax.ws.rs.HttpMethod.GET;
-import static javax.ws.rs.HttpMethod.PUT;
-import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.MESSAGE;
-import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_DELETE;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_PUT;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.UUID;
 
 import java.util.List;
@@ -62,7 +60,6 @@ public class DocumentResource {
         Context context = new Context();
         context.setUuids(uuidString);
         context.setCollection(collection);
-        context.addParameter(METHOD, GET);
         
         HandlerChain handlerChain = getHandlerChain(collection, GET_BY_ID);
         return handlerChain.execute(context);
@@ -79,7 +76,6 @@ public class DocumentResource {
         context.setUriInfo(uriInfo);
         context.setHttpHeaders(httpHeaders);
         context.setCollection(collection);
-        context.addParameter(METHOD, GET);
         
         HandlerChain handlerChain = getHandlerChain(collection, GET_FILTERED);
         return handlerChain.execute(context);
@@ -107,7 +103,6 @@ public class DocumentResource {
         context.setHttpHeaders(httpHeaders);
         context.setCollection(collection);
         context.setUuids(uuidList);
-        context.addParameter(METHOD, POST);
 
         HandlerChain handlerChain = getHandlerChain(collection, GET_MULTIPLE_FILTERED);
         return handlerChain.execute(context);
@@ -127,9 +122,9 @@ public class DocumentResource {
         context.setUuids(uuidString);
         context.setContentMap(contentMap);
         context.setUriInfo(uriInfo);
-        context.addParameter(METHOD, PUT);
 
-        logger.withMetodName("writeInCollection").withRequestParameters(context, "/{collection}/{uuidString}")
+        logger.withMetodName("writeInCollection")
+                .withRequestParameters(context, METHOD_PUT, "/{collection}/{uuidString}")
                 .withUriInfo(uriInfo).withField(UUID, uuidString);
 
         try {
@@ -156,9 +151,9 @@ public class DocumentResource {
         context.setUuids(uuidString);
         context.setCollection(collection);
         context.setUriInfo(uriInfo);
-        context.addParameter(METHOD, "DELETE");
 
-        logger.withMetodName("deleteFromCollection").withRequestParameters(context, "/{collection}/{uuidString}")
+        logger.withMetodName("deleteFromCollection")
+                .withRequestParameters(context, METHOD_DELETE, "/{collection}/{uuidString}")
                 .withUriInfo(uriInfo).withField(UUID, uuidString);
 
         try {

--- a/src/main/java/com/ft/universalpublishing/documentstore/target/DeleteDocumentTarget.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/target/DeleteDocumentTarget.java
@@ -4,8 +4,7 @@ import com.ft.universalpublishing.documentstore.exception.DocumentNotFoundExcept
 import com.ft.universalpublishing.documentstore.model.read.Context;
 import com.ft.universalpublishing.documentstore.service.MongoDocumentStoreService;
 
-import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD;
-import static java.lang.String.valueOf;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_DELETE;
 import static java.util.UUID.fromString;
 import static javax.ws.rs.core.Response.ok;
 
@@ -22,7 +21,7 @@ public class DeleteDocumentTarget implements Target {
     public Object execute(Context context) {
         try {
             documentStoreService.delete(context.getCollection(),
-                    fromString(context.getUuid()), valueOf(context.getParameter(METHOD)));
+                    fromString(context.getUuid()), METHOD_DELETE);
             return ok().build();
         } catch (DocumentNotFoundException e) {
             return ok().build();

--- a/src/main/java/com/ft/universalpublishing/documentstore/target/FindListByConceptAndTypeTarget.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/target/FindListByConceptAndTypeTarget.java
@@ -12,9 +12,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.ft.api.jaxrs.errors.ClientError.status;
-import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_GET;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.STATUS;
-import static java.lang.String.valueOf;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 
 
@@ -35,7 +34,7 @@ public class FindListByConceptAndTypeTarget implements Target {
         String listType = (String) context.getParameter("listType");
 
         Map<String, Object> result = documentStoreService.findByConceptAndType(context.getCollection(), conceptId,
-                listType, valueOf(context.getParameter(METHOD)));
+                listType, METHOD_GET);
         if (result == null) {
             throw new DocumentNotFoundException(conceptId);
         }

--- a/src/main/java/com/ft/universalpublishing/documentstore/target/FindListByUuid.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/target/FindListByUuid.java
@@ -10,9 +10,8 @@ import com.ft.universalpublishing.documentstore.utils.FluentLoggingWrapper;
 import java.util.Map;
 
 import static com.ft.api.jaxrs.errors.ClientError.status;
-import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_GET;
 import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.STATUS;
-import static java.lang.String.valueOf;
 import static java.util.UUID.fromString;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 
@@ -30,7 +29,7 @@ public class FindListByUuid implements Target {
     @Override
     public Object execute(Context context) {
         Map<String, Object> contentMap = documentStoreService.findByUuid(context.getCollection(),
-                fromString(context.getUuid()), valueOf(context.getParameter(METHOD)));
+                fromString(context.getUuid()), METHOD_GET);
         try {
             ContentList contentList = new ObjectMapper().convertValue(contentMap, ContentList.class);
             contentList.addIds();

--- a/src/main/java/com/ft/universalpublishing/documentstore/target/FindMultipleResourcesByUuidsTarget.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/target/FindMultipleResourcesByUuidsTarget.java
@@ -3,8 +3,7 @@ package com.ft.universalpublishing.documentstore.target;
 import com.ft.universalpublishing.documentstore.model.read.Context;
 import com.ft.universalpublishing.documentstore.service.MongoDocumentStoreService;
 
-import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD;
-import static java.lang.String.valueOf;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_GET;
 
 import java.util.ArrayList;
 
@@ -20,6 +19,6 @@ public class FindMultipleResourcesByUuidsTarget implements Target {
     @Override
     public Object execute(Context context) {
         return new ArrayList<>(documentStoreService.findByUuids(context.getCollection(), context.getValidatedUuids(),
-                valueOf(context.getParameter(METHOD))));
+                METHOD_GET));
     }
 }

--- a/src/main/java/com/ft/universalpublishing/documentstore/target/FindResourceByUuidTarget.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/target/FindResourceByUuidTarget.java
@@ -3,8 +3,7 @@ package com.ft.universalpublishing.documentstore.target;
 import com.ft.universalpublishing.documentstore.model.read.Context;
 import com.ft.universalpublishing.documentstore.service.MongoDocumentStoreService;
 
-import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD;
-import static java.lang.String.valueOf;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_GET;
 import static java.util.UUID.fromString;
 
 public class FindResourceByUuidTarget implements Target {
@@ -18,6 +17,6 @@ public class FindResourceByUuidTarget implements Target {
     @Override
     public Object execute(Context context) {
         return documentStoreService.findByUuid(context.getCollection(), fromString(context.getUuid()),
-                valueOf(context.getParameter(METHOD)));
+                METHOD_GET);
     }
 }

--- a/src/main/java/com/ft/universalpublishing/documentstore/target/WriteDocumentTarget.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/target/WriteDocumentTarget.java
@@ -5,12 +5,9 @@ import com.ft.universalpublishing.documentstore.service.MongoDocumentStoreServic
 import com.ft.universalpublishing.documentstore.utils.FluentLoggingWrapper;
 import com.ft.universalpublishing.documentstore.write.DocumentWritten;
 
-import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD;
-import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.TRANSACTION_ID;
-import static java.lang.String.valueOf;
+import static com.ft.universalpublishing.documentstore.utils.FluentLoggingUtils.METHOD_POST;
 import static javax.ws.rs.core.Response.created;
 import static javax.ws.rs.core.Response.ok;
-import static org.slf4j.MDC.get;
 
 import javax.ws.rs.core.Response;
 
@@ -26,7 +23,7 @@ public class WriteDocumentTarget implements Target {
     @Override
     public Object execute(Context context) {
         final DocumentWritten written = documentStoreService.write(context.getCollection(), context.getContentMap(),
-                valueOf(context.getParameter(METHOD)));
+                METHOD_POST);
         final Response response;
         switch (written.getMode()) {
             case Created:
@@ -39,11 +36,6 @@ public class WriteDocumentTarget implements Target {
                 throw new IllegalStateException("unknown write mode " + written.getMode());
         }
         
-        new FluentLoggingWrapper().withClassName(this.getClass().getCanonicalName())
-                .withMetodName("execute").withResponse(response)
-                .withTransactionId(get(TRANSACTION_ID)).withField(METHOD, valueOf(context.getParameter(METHOD)))
-                .build().logInfo();
-
         return response;
     }
 }

--- a/src/main/java/com/ft/universalpublishing/documentstore/utils/FluentLoggingUtils.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/utils/FluentLoggingUtils.java
@@ -5,7 +5,10 @@ public interface FluentLoggingUtils {
     String CLIENT = "client";
     String CLASS = "class";
     String METHOD = "method";
-    String METHOD_VALUE = "GET";
+    String METHOD_GET = "GET";
+    String METHOD_POST = "POST";
+    String METHOD_PUT = "PUT";
+    String METHOD_DELETE = "DELETE";
     String HOST = "host";
     String STATUS = "status";
     String ACCEPT = "accept";
@@ -16,8 +19,8 @@ public interface FluentLoggingUtils {
     String MESSAGE = "msg";
     String REASON = "reason";
     String RESPONSE = "response";
-    String EXCEPTION = "exception: ";
-    String STACKTRACE = "stacktrace: ";
+    String EXCEPTION = "exception_message";
+    String STACKTRACE = "stacktrace_log";
     String CONTENT_TYPE = "content-type";
     String USER_AGENT = "userAgent";
     String COLLECTION = "collection";

--- a/src/main/java/com/ft/universalpublishing/documentstore/utils/FluentLoggingWrapper.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/utils/FluentLoggingWrapper.java
@@ -84,8 +84,8 @@ public class FluentLoggingWrapper {
         return this;
     }
 
-    public FluentLoggingWrapper withRequestParameters(Context context, String path) {
-        withField(METHOD, context.getParameter(METHOD));
+    public FluentLoggingWrapper withRequestParameters(Context context, String method, String path) {
+        withField(METHOD, method);
         withField(PATH, path);
         if (nonNull(context.getContentMap())) {
             withField(CONTENT_TYPE, context.getContentMap().get("type"));
@@ -140,7 +140,6 @@ public class FluentLoggingWrapper {
         iy.yielding(SYSTEM_CODE, APPLICATION_NAME);
         iy.yielding(items);
         items = new HashMap<>();
-        methodName = "";
         return iy;
     }
 

--- a/src/test/resources/config-no-mongo-test.yml
+++ b/src/test/resources/config-no-mongo-test.yml
@@ -33,15 +33,12 @@ server:
 
   requestLog:
     appenders:
-
       - type: console
         # Add format needed for 'fluent-logging' library to make in JSON format
         logFormat: "%m%n"
         # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
         timeZone: UTC
-
       - type: file
-
         # The file to which current statements will be logged.
         currentLogFilename: /var/log/apps/document-store-api-dw-access.log
 
@@ -49,10 +46,8 @@ server:
         # %d is replaced with the previous day (yyyy-MM-dd). Custom rolling windows can be created
         # by passing a SimpleDateFormat-compatible format as an argument: "%d{yyyy-MM-dd-hh}".
         archivedLogFilenamePattern: /var/log/apps/document-store-api-dw-access-%d.log.gz
-
         # The number of archived files to keep.
         archivedFileCount: 6
-
         # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
         timeZone: UTC
 


### PR DESCRIPTION
Removed 'methodName' becoming empty in build operation