### PR TITLE
Remove validation for generic lists

### DIFF
--- a/src/main/java/com/ft/universalpublishing/documentstore/DocumentStoreApiApplication.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/DocumentStoreApiApplication.java
@@ -155,7 +155,7 @@ public class DocumentStoreApiApplication extends Application<DocumentStoreApiCon
         collections.put(new Pair<>("generic-lists", Operation.GET_BY_ID),
                 new HandlerChain().addHandlers(uuidValidationHandler).setTarget(findListByUuid));
         collections.put(new Pair<>("generic-lists", Operation.ADD),
-                new HandlerChain().addHandlers(uuidValidationHandler, contentListValidationHandler).setTarget(writeDocument));
+                new HandlerChain().addHandlers(uuidValidationHandler).setTarget(writeDocument));
         collections.put(new Pair<>("generic-lists", Operation.REMOVE),
                 new HandlerChain().addHandlers(uuidValidationHandler).setTarget(deleteDocument));
 


### PR DESCRIPTION
This small change removes the validation for `generic lists` that is happening inside the document-store-api service.

The validation here is unnecessary as we are validating all generic content against the relevant [json/xml schemas](https://github.com/Financial-Times/upp-schema-reader) during publishing.