### PR TITLE
Add runbook

### DIFF
--- a/.github/runbooks.yml
+++ b/.github/runbooks.yml
@@ -1,0 +1,38 @@
+# These settings determine the behaviour of runbook.md's Runbook Validator bot
+# https://github.com/financial-times/runbook.md
+
+# Everything below is optional
+
+runbooks:
+  # All available settings are listed below
+
+  # Disable checks for this repo
+  # defaults to `false`
+  disabled: false
+
+  ### SUPPORT FOR MULTIPLE RUNBOOKS IN A SINGLE REPOSITORY
+
+  # Fail checks if `any` | `all` | `none` runbooks fail validation
+  # defaults to `any`
+  failOn: any
+
+  ### SUPPORT FOR UPDATING BIZ-OPS
+
+  # Update valid Biz-Ops runbooks on merge to a specific branch
+  #### IF YOUR DEPLOYMENTS ARE AUTOMATED (CircleCI, Heroku Pipelines)
+  #### PLEASE INTEGRATE WITH CHANGE-API INSTEAD
+  #### https://github.com/Financial-Times/change-api#change-api---v2
+  # defaults to `false`
+  updateOnMerge: true
+
+  # Merges to this branch trigger Biz-Ops updates updateOnMerge is `true`
+  # defaults to `master`
+  updateBranch: master
+
+  ### UPDATING BIZ-OPS REQUIRES EACH RUNBOOK TO BE TIED TO A VALID SYSTEM CODE
+  # Mappings between paths and system codes
+  # unless a custom mapping is specified here
+  # runbook.md tries to parse the system code from the runbook's filename (format: my-sys-code_runbook.md)
+  systemCodes:
+    # paths are relative to root, omitting ./ (case-insensitive)
+    document-store-api: runbooks/runbook.md

--- a/README.md
+++ b/README.md
@@ -4,15 +4,9 @@
 
 Document Store API is a Dropwizard application which allows writes to and reads from MongoDB.
 
-Reading content by API users should be done via the /content-read/{uuid} endpoint. This makes sure the format of the response obeys the contract that our API was designed by.
-
 The /content/{uuid} endpoint is for reading from mongo without any other restriction, no formatting, no hard-coded layout or classes. It's a pure document representation of what is stored in mongoDB.
 
-These two endpoints should be separated into two independent applications, all of them using the name /content, one reading, one formatting, but that was scheduled to be later, for now both layers are in the same app.
-
-Operations on lists DOES NOT share the same logic, their read/writes are separate from this mechanism.
-
-The endpoints which retrieve /lists invoke the **public-concepts-api** and **public-concordances-api** services in order to display the lists with their most up-to-date concepts.
+Operations on lists DOES NOT share the same logic, their read/writes are separate from this mechanism. New endpoints were added for lists: `/lists`, they call **public-concepts-api** and **public-concordances-api** services in order to return lists with their most up-to-date concepts.
 
 ## Running locally
 

--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,0 +1,119 @@
+# UPP - Document Store API
+
+The Document Store API writes to and reads from Document Store (MongoDB) in the Delivery cluster.
+
+## Primary URL
+
+https://upp-prod-delivery-glb.upp.ft.com/__document-store-api/
+
+## Service Tier
+
+Platinum
+
+## Lifecycle Stage
+
+Production
+
+## Delivered By
+
+content
+
+## Supported By
+
+content
+
+## Known About By
+
+- hristo.georgiev
+- robert.marinov
+- elina.kaneva
+- georgi.ivanov
+- tsvetan.dimitrov
+- georgi.kazakov
+- kalin.arsov
+- mihail.mihaylov
+- boyko.boykov
+- dimitar.terziev
+
+## Host Platform
+
+AWS
+
+## Architecture
+
+Document Store API allows writes to and reads from MongoDB. Endpoints: `/content` and `/lists`. If this service is unavailable no publishes nor reads from the APIs will be working as expected.
+
+## Contains Personal Data
+
+No
+
+## Contains Sensitive Data
+
+No
+
+## Dependencies
+
+- upp-mongodb
+- public-concepts-api
+- public-concordances-api
+
+## Failover Architecture Type
+
+ActiveActive
+
+## Failover Process Type
+
+FullyAutomated
+
+## Failback Process Type
+
+FullyAutomated
+
+## Failover Details
+
+The service is deployed in both Delivery clusters. The failover guide for the cluster is located here:
+https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/delivery-cluster
+
+## Data Recovery Process Type
+
+NotApplicable
+
+## Data Recovery Details
+
+The service does not store data, so it does not require any data recovery steps.
+
+## Release Process Type
+
+PartiallyAutomated
+
+## Rollback Process Type
+
+Manual
+
+## Release Details
+
+Manual failover is needed when a new version of the service is deployed to production. Otherwise, an automated failover is going to take place when releasing.
+For more details about the failover process please see: https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/delivery-cluster
+
+## Key Management Process Type
+
+Manual
+
+## Key Management Details
+
+To access the service clients need to provide basic auth credentials.
+To rotate credentials you need to login to a particular cluster and update varnish-auth secrets.
+
+## Monitoring
+
+Service in UPP K8S delivery clusters:
+- Delivery-Prod-EU health: https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=document-store-api
+- Delivery-Prod-US health: https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=document-store-api
+
+## First Line Troubleshooting
+
+https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting
+
+## Second Line Troubleshooting
+
+Please refer to the GitHub repository README for troubleshooting information.


### PR DESCRIPTION
What is new:
- Add runbook
- Update README where some very old pieces were found - e.g. non-existent `/content-read` endpoint.