### PR TITLE
Feature/uppsf 1426 cph discovery

### DIFF
--- a/src/main/java/com/ft/universalpublishing/documentstore/DocumentStoreApiApplication.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/DocumentStoreApiApplication.java
@@ -40,6 +40,7 @@ import com.ft.universalpublishing.documentstore.service.filter.CacheControlFilte
 import com.ft.universalpublishing.documentstore.target.ApplyConcordedConceptToListTarget;
 import com.ft.universalpublishing.documentstore.target.ApplyConcordedConceptsToListsTarget;
 import com.ft.universalpublishing.documentstore.target.DeleteDocumentTarget;
+import com.ft.universalpublishing.documentstore.target.FilterContentTarget;
 import com.ft.universalpublishing.documentstore.target.FindMultipleResourcesByUuidsTarget;
 import com.ft.universalpublishing.documentstore.target.FindResourceByUuidTarget;
 import com.ft.universalpublishing.documentstore.target.Target;
@@ -185,6 +186,7 @@ public class DocumentStoreApiApplication extends Application<DocumentStoreApiCon
         new ApplyConcordedConceptToListTarget(publicConceptsApiService, configuration.getApiHost());
     Target applyConcordedConceptsToLists =
         new ApplyConcordedConceptsToListsTarget(publicConceptsApiService);
+    Target filterContentTarget = new FilterContentTarget(documentStoreService);
 
     final Map<Pair<String, Operation>, HandlerChain> collections = new HashMap<>();
     collections.put(
@@ -228,6 +230,9 @@ public class DocumentStoreApiApplication extends Application<DocumentStoreApiCon
     collections.put(
         new Pair<>("complementarycontent", Operation.REMOVE),
         new HandlerChain().addHandlers(uuidValidationHandler).setTarget(deleteDocument));
+    collections.put(
+        new Pair<>("complementarycontent", Operation.SEARCH),
+        new HandlerChain().setTarget(filterContentTarget));
 
     collections.put(
         new Pair<>("internalcomponents", Operation.GET_FILTERED),

--- a/src/main/java/com/ft/universalpublishing/documentstore/handler/FilterListsHandler.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/handler/FilterListsHandler.java
@@ -16,8 +16,13 @@ public class FilterListsHandler implements Handler {
   public void handle(Context context) {
     UUID[] conceptUUIDs = (UUID[]) context.getParameter("conceptUUIDs");
     List<Document> listDocuments =
-        documentStoreService.filterLists(
-            context.getCollection(), conceptUUIDs, context.getListType(), context.getSearchTerm());
+        documentStoreService.filterCollection(
+            context.getCollection(),
+            conceptUUIDs,
+            context.getListType(),
+            context.getSearchTerm(),
+            context.getWebUrl(),
+            context.getStandfirst());
 
     context.setDocuments(listDocuments);
   }

--- a/src/main/java/com/ft/universalpublishing/documentstore/model/read/Context.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/model/read/Context.java
@@ -14,25 +14,18 @@ import org.bson.Document;
 
 @Data
 public class Context {
-
   private Map<String, Object> map;
-
   private List<String> uuids;
-
   private String collection;
-
   private Map<String, Object> contentMap;
-
   private Set<UUID> validatedUuids;
-
   private UriInfo uriInfo;
-
   private HttpHeaders httpHeaders;
-
   private String conceptUUID;
   private String listType;
   private String searchTerm;
-
+  private String webUrl;
+  private String standfirst;
   private List<Document> documents;
 
   public Context() {
@@ -40,20 +33,8 @@ public class Context {
     map = new HashMap<>();
   }
 
-  public List<Document> getDocuments() {
-    return documents;
-  }
-
-  public void setDocuments(List<Document> documents) {
-    this.documents = documents;
-  }
-
   public String getUuid() {
     return uuids.get(0);
-  }
-
-  public List<String> getUuids() {
-    return uuids;
   }
 
   public void setUuids(List<String> uuids) {
@@ -70,29 +51,5 @@ public class Context {
 
   public Object getParameter(String key) {
     return map.get(key);
-  }
-
-  public void setConceptUUID(String conceptUUID) {
-    this.conceptUUID = conceptUUID;
-  }
-
-  public void setListType(String listType) {
-    this.listType = listType;
-  }
-
-  public void setSearchTerm(String searchTerm) {
-    this.searchTerm = searchTerm;
-  }
-
-  public String getConceptUUID() {
-    return this.conceptUUID;
-  }
-
-  public String getListType() {
-    return this.listType;
-  }
-
-  public String getSearchTerm() {
-    return this.searchTerm;
   }
 }

--- a/src/main/java/com/ft/universalpublishing/documentstore/resources/DocumentResource.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/resources/DocumentResource.java
@@ -59,12 +59,17 @@ public class DocumentResource {
       @PathParam("collection") String collection,
       @QueryParam("conceptUUID") String conceptUUID,
       @QueryParam("listType") String listType,
-      @QueryParam("searchTerm") String searchTerm) {
+      @QueryParam("searchTerm") String searchTerm,
+      @QueryParam("webUrl") String webUrl,
+      @QueryParam("standfirst") String standfirst) {
     Context context = new Context();
     context.setCollection(collection);
     context.setConceptUUID(conceptUUID);
     context.setListType(listType);
     context.setSearchTerm(searchTerm);
+    context.setWebUrl(webUrl);
+    context.setStandfirst(standfirst);
+
     HandlerChain handlerChain = getHandlerChain(collection, Operation.SEARCH);
     return handlerChain.execute(context);
   }

--- a/src/main/java/com/ft/universalpublishing/documentstore/target/FilterContentTarget.java
+++ b/src/main/java/com/ft/universalpublishing/documentstore/target/FilterContentTarget.java
@@ -1,0 +1,31 @@
+package com.ft.universalpublishing.documentstore.target;
+
+import com.ft.universalpublishing.documentstore.model.read.Context;
+import com.ft.universalpublishing.documentstore.service.MongoDocumentStoreService;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.bson.Document;
+
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class FilterContentTarget implements Target {
+  private final MongoDocumentStoreService documentStoreService;
+
+  @Override
+  public Object execute(Context context) {
+    UUID[] conceptUUIDs = (UUID[]) context.getParameter("conceptUUIDs");
+    List<Document> listDocuments =
+        documentStoreService.filterCollection(
+            context.getCollection(),
+            conceptUUIDs,
+            context.getListType(),
+            context.getSearchTerm(),
+            context.getWebUrl(),
+            context.getStandfirst());
+
+    return listDocuments;
+  }
+}

--- a/src/test/java/com/ft/universalpublishing/documentstore/resources/DocumentSearchComplementaryContentResourceEndpointTest.java
+++ b/src/test/java/com/ft/universalpublishing/documentstore/resources/DocumentSearchComplementaryContentResourceEndpointTest.java
@@ -1,0 +1,158 @@
+package com.ft.universalpublishing.documentstore.resources;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.ft.universalpublishing.documentstore.handler.HandlerChain;
+import com.ft.universalpublishing.documentstore.model.read.ContentList;
+import com.ft.universalpublishing.documentstore.model.read.Operation;
+import com.ft.universalpublishing.documentstore.model.read.Pair;
+import com.ft.universalpublishing.documentstore.service.MongoDocumentStoreService;
+import com.ft.universalpublishing.documentstore.target.FilterContentTarget;
+import com.ft.universalpublishing.documentstore.target.Target;
+import com.ft.universalpublishing.documentstore.validators.ContentListValidator;
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import com.google.common.io.Resources;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.ws.rs.core.Response;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class DocumentSearchComplementaryContentResourceEndpointTest {
+  private static final MongoDocumentStoreService documentStoreService =
+      mock(MongoDocumentStoreService.class);
+  private static final ContentListValidator contentListValidator = mock(ContentListValidator.class);
+  private static final String COLLECTION_NAME = "complementarycontent";
+
+  private static final ResourceExtension resources =
+      ResourceExtension.builder().addResource(new DocumentResource(getCollectionMap())).build();
+  private static String CONTENT_PLACEHOLDER_MOCK_STRING = null;
+
+  public DocumentSearchComplementaryContentResourceEndpointTest() {}
+
+  @BeforeEach
+  public void setup() {
+    reset(documentStoreService);
+    reset(contentListValidator);
+  }
+
+  @Test
+  public void shouldReturn200ForEmptySearch() throws JsonMappingException, JsonProcessingException {
+    final List<Document> dataDocuments = createContentPlaceholderDocumentsList(3);
+
+    when(documentStoreService.filterCollection(
+            eq(COLLECTION_NAME), eq(null), eq(null), eq(null), eq(null), eq(null)))
+        .thenReturn(dataDocuments);
+
+    final Response clientResponse =
+        resources.client().target("/search/complementarycontent").request().get();
+
+    verify(documentStoreService)
+        .filterCollection(eq(COLLECTION_NAME), eq(null), eq(null), eq(null), eq(null), eq(null));
+
+    assertThat("response", clientResponse, hasProperty("status", equalTo(200)));
+    final List<ContentList> retrievedDocuments =
+        Arrays.asList(clientResponse.readEntity(ContentList[].class));
+
+    assertThat(retrievedDocuments.size(), equalTo(dataDocuments.size()));
+  }
+
+  @Test
+  public void shouldReturn200ForGivenSearchTermWebUrlAndStandfirst()
+      throws JsonMappingException, JsonProcessingException {
+    final String title = "New Title";
+    final String webUrl = "http://www.ft.com/ig/sites/2014/virgingroup-timeline-changed/";
+    final String standfirst = "New Standfirst";
+
+    final List<Document> dataDocuments = createContentPlaceholderDocumentsList(3);
+    dataDocuments.get(0).put("title", title);
+    dataDocuments.get(0).put("webUrl", webUrl);
+    dataDocuments.get(0).put("standfirst", standfirst);
+
+    when(documentStoreService.filterCollection(
+            eq(COLLECTION_NAME), eq(null), eq(null), eq(title), eq(webUrl), eq(standfirst)))
+        .thenReturn(dataDocuments);
+
+    final Response clientResponse =
+        resources
+            .client()
+            .target("/search/complementarycontent")
+            .queryParam("webUrl", webUrl)
+            .queryParam("searchTerm", title)
+            .queryParam("standfirst", standfirst)
+            .request()
+            .get();
+
+    verify(documentStoreService)
+        .filterCollection(
+            eq(COLLECTION_NAME), eq(null), eq(null), eq(title), eq(webUrl), eq(standfirst));
+
+    assertThat("response", clientResponse, hasProperty("status", equalTo(200)));
+    final List<Document> retrievedDocuments =
+        Arrays.asList(clientResponse.readEntity(Document[].class));
+
+    assertThat(retrievedDocuments.size(), equalTo(dataDocuments.size()));
+    assertThat(retrievedDocuments, equalTo(dataDocuments));
+  }
+
+  private static Map<Pair<String, Operation>, HandlerChain> getCollectionMap() {
+    Target filterContentTarget = new FilterContentTarget(documentStoreService);
+
+    final Map<Pair<String, Operation>, HandlerChain> collections = new HashMap<>();
+
+    collections.put(
+        new Pair<>("complementarycontent", Operation.SEARCH),
+        new HandlerChain().setTarget(filterContentTarget));
+
+    return collections;
+  }
+
+  private void readCPHMock() {
+    URL url = Resources.getResource("cph-mock.json");
+    try {
+      CONTENT_PLACEHOLDER_MOCK_STRING = Resources.toString(url, Charsets.UTF_8);
+    } catch (IOException e) {
+      fail("Error parsing chp-mock.json file");
+    }
+  }
+
+  private Document createContentPlaceholderDocument() {
+    if (Strings.isNullOrEmpty(CONTENT_PLACEHOLDER_MOCK_STRING)) {
+      readCPHMock();
+    }
+    Document contentPlaceholderDocument = Document.parse(CONTENT_PLACEHOLDER_MOCK_STRING);
+    contentPlaceholderDocument.put("uuid", UUID.randomUUID().toString());
+    return contentPlaceholderDocument;
+  }
+
+  private List<Document> createContentPlaceholderDocumentsList(int count) {
+    final List<Document> dataDocuments = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      dataDocuments.add(createContentPlaceholderDocument());
+    }
+
+    return dataDocuments;
+  }
+}

--- a/src/test/java/com/ft/universalpublishing/documentstore/resources/DocumentSearchListResourceEndpointTest.java
+++ b/src/test/java/com/ft/universalpublishing/documentstore/resources/DocumentSearchListResourceEndpointTest.java
@@ -94,7 +94,8 @@ public class DocumentSearchListResourceEndpointTest {
             .map(concept -> concept.getUuid().toString())
             .collect(Collectors.toSet());
 
-    when(documentStoreService.filterLists(eq(RESOURCE_TYPE), eq(null), eq(null), eq(null)))
+    when(documentStoreService.filterCollection(
+            eq(RESOURCE_TYPE), eq(null), eq(null), eq(null), eq(null), eq(null)))
         .thenReturn(documents);
     when(publicConceptsApiService.searchConcepts(any(String[].class)))
         .thenReturn(searchConceptsResults);
@@ -103,7 +104,8 @@ public class DocumentSearchListResourceEndpointTest {
 
     final ArgumentCaptor<String[]> conceptsCaptor = ArgumentCaptor.forClass(String[].class);
     verify(publicConcordancesApiService, times(0)).getUPPConcordances(anyString());
-    verify(documentStoreService).filterLists(eq(RESOURCE_TYPE), eq(null), eq(null), eq(null));
+    verify(documentStoreService)
+        .filterCollection(eq(RESOURCE_TYPE), eq(null), eq(null), eq(null), eq(null), eq(null));
     verify(publicConceptsApiService).searchConcepts(conceptsCaptor.capture());
 
     final List<String> searchConceptsParam = Arrays.asList(conceptsCaptor.getValue());
@@ -136,7 +138,8 @@ public class DocumentSearchListResourceEndpointTest {
 
     final UUID[] conceptParams = new UUID[] {contentLists.get(listIndex).getConcept().getUuid()};
 
-    when(documentStoreService.filterLists(eq(RESOURCE_TYPE), eq(conceptParams), eq(null), eq(null)))
+    when(documentStoreService.filterCollection(
+            eq(RESOURCE_TYPE), eq(conceptParams), eq(null), eq(null), eq(null), eq(null)))
         .thenReturn(documents);
     when(publicConceptsApiService.searchConcepts(any(String[].class)))
         .thenReturn(searchConceptsResults);
@@ -152,7 +155,8 @@ public class DocumentSearchListResourceEndpointTest {
     final ArgumentCaptor<String[]> conceptsCaptor = ArgumentCaptor.forClass(String[].class);
     verify(publicConcordancesApiService).getUPPConcordances(eq(conceptParams[0].toString()));
     verify(documentStoreService)
-        .filterLists(eq(RESOURCE_TYPE), eq(conceptParams), eq(null), eq(null));
+        .filterCollection(
+            eq(RESOURCE_TYPE), eq(conceptParams), eq(null), eq(null), eq(null), eq(null));
     verify(publicConceptsApiService).searchConcepts(conceptsCaptor.capture());
 
     final List<String> searchConceptsParam = Arrays.asList(conceptsCaptor.getValue());
@@ -202,8 +206,8 @@ public class DocumentSearchListResourceEndpointTest {
     final String title = "New Title";
 
     when(publicConcordancesApiService.getUPPConcordances(eq(conceptUUID))).thenReturn(concordances);
-    when(documentStoreService.filterLists(
-            eq(RESOURCE_TYPE), eq(conceptParams), eq(listType), eq(title)))
+    when(documentStoreService.filterCollection(
+            eq(RESOURCE_TYPE), eq(conceptParams), eq(listType), eq(title), eq(null), eq(null)))
         .thenReturn(documents);
     when(publicConceptsApiService.searchConcepts(any(String[].class)))
         .thenReturn(searchConceptsResults);
@@ -221,7 +225,8 @@ public class DocumentSearchListResourceEndpointTest {
     final ArgumentCaptor<String[]> conceptsCaptor = ArgumentCaptor.forClass(String[].class);
     verify(publicConcordancesApiService).getUPPConcordances(eq(conceptUUID));
     verify(documentStoreService)
-        .filterLists(eq(RESOURCE_TYPE), eq(conceptParams), eq(listType), eq(title));
+        .filterCollection(
+            eq(RESOURCE_TYPE), eq(conceptParams), eq(listType), eq(title), eq(null), eq(null));
     verify(publicConceptsApiService).searchConcepts(conceptsCaptor.capture());
 
     final List<String> searchConceptsParam = Arrays.asList(conceptsCaptor.getValue());

--- a/src/test/java/com/ft/universalpublishing/documentstore/service/MongoDocumentStoreServiceListDiscoveryAPITest.java
+++ b/src/test/java/com/ft/universalpublishing/documentstore/service/MongoDocumentStoreServiceListDiscoveryAPITest.java
@@ -373,14 +373,15 @@ public class MongoDocumentStoreServiceListDiscoveryAPITest {
 
     String webUrl = TEST_DATA_All.get("webUrl").toString();
     String standfirst = TEST_DATA_All.get("standfirst").toString();
-    String searchTerm = TEST_DATA_All.get("title").toString();
+    String title = TEST_DATA_All.get("title").toString();
+    String searchTerm = title.substring(1, title.length() - 2);
 
     List<Document> filteredEntries =
         mongoDocumentStoreService.filterCollection(
             COLLECTION_NAME, null, null, searchTerm, webUrl, standfirst);
     filteredEntries.forEach(
         entry -> {
-          assertThat(entry.get("title"), is(searchTerm));
+          assertThat(entry.get("title"), is(title));
           assertThat(entry.get("webUrl"), is(webUrl));
           assertThat(entry.get("standfirst"), is(standfirst));
         });

--- a/src/test/resources/cph-mock.json
+++ b/src/test/resources/cph-mock.json
@@ -1,0 +1,32 @@
+{
+    "alternativeImages": {
+        "promotionalImage": {
+            "id": "8f7b3e6a-327b-11e3-91d2-00144feab7de"
+        }
+    },
+    "alternativeStandfirsts": {
+        "promotionalStandfirst": "Long standfirst here"
+    },
+    "alternativeTitles": {
+        "promotionalTitle": "Test: Generic CPH"
+    },
+    "canBeDistributed": "verify",
+    "canBeSyndicated": "verify",
+    "canonicalWebUrl": "https://www.ft.com/content/f2ba7ff0-1626-40ec-b281-2e3775e854ee",
+    "description": "Description goes here",
+    "identifiers": [
+        {
+            "authority": "http://api.ft.com/system/cct",
+            "identifierValue": "f2ba7ff0-1626-40ec-b281-2e3775e854ee"
+        }
+    ],
+    "lastModified": "2020-06-01T11:47:39.080Z",
+    "mainImage": "27255a90-e4d8-4dd1-bfb4-e72d67683f80",
+    "publishReference": "test_789",
+    "publishedDate": "2020-05-05T01:37:00.000Z",
+    "standfirst": "standfirst here",
+    "title": "Test: Generic Content Placeholder",
+    "type": "Content",
+    "uuid": "16e4a2dd-b4be-440d-b4c1-04f0dc8da366",
+    "webUrl": "http://www.ft.com/ig/sites/2014/virgingroup-timeline/"
+}


### PR DESCRIPTION
This PR introduces the `/search/complementarycontent` endpoint that can be invoked using any of the `webUrl` `searchTerm` and `standfirst` query params.

Note:  Some of the _getters_ and _setters_ in `Context.java` have been removed, because they can be generated by the `@Data` annotation.