### PR TITLE
Use docker multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN apk --update add git maven curl \
   && apk del go git maven \
   && rm -rf /var/cache/apk/* /document-store-api/target* /root/.m2/* /tmp/*.apk
 
+FROM openjdk:8u212-jdk-alpine3.9
+COPY --from=0 /document-store-api.jar /document-store-api.jar
+COPY --from=0 /config.yaml /config.yaml
+
 EXPOSE 8080 8081
 
 CMD exec java $JAVA_OPTS \


### PR DESCRIPTION
# Description

## What

Implement Docker multistage build.

## Why

So that we don't leak credentials that are needed only for build stage in DockerHub.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [X] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
