### PR TITLE
Use separate affinity rules for EU and US

### DIFF
--- a/config-local.yml
+++ b/config-local.yml
@@ -33,7 +33,7 @@ server:
     appenders:
       - type: console
         # Add transaction_id to the end of Dropwizard's default format, which is itself based on the "combined" log format
-        logFormat: '%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D transaction_id=%i{X-Request-Id}'
+        logFormat: '%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" response_time=%D transaction_id=%i{X-Request-Id}'
         # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
         timeZone: UTC
 

--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,7 @@ server:
     appenders:
       - type: console
         # Add transaction_id to the end of Dropwizard's default format, which is itself based on the "combined" log format
-        logFormat: '%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D transaction_id=%i{X-Request-Id}'
+        logFormat: '%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" response_time=%D transaction_id=%i{X-Request-Id}'
         # The timezone used to format dates. HINT: USE THE DEFAULT, UTC.
         timeZone: UTC
 

--- a/helm/document-store-api/app-configs/document-store-api_eks_delivery.yaml
+++ b/helm/document-store-api/app-configs/document-store-api_eks_delivery.yaml
@@ -2,3 +2,24 @@ replicaCount: 2
 
 service:
   name: document-store-api
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - document-store-api
+      topologyKey: "kubernetes.io/hostname"
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - content-public-read
+        topologyKey: "kubernetes.io/hostname"

--- a/helm/document-store-api/app-configs/document-store-api_eks_delivery_prod_us.yaml
+++ b/helm/document-store-api/app-configs/document-store-api_eks_delivery_prod_us.yaml
@@ -1,0 +1,14 @@
+replicaCount: 2
+
+service:
+  name: document-store-api
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+              - us-east-1a

--- a/helm/document-store-api/app-configs/document-store-api_eks_delivery_staging_us.yaml
+++ b/helm/document-store-api/app-configs/document-store-api_eks_delivery_staging_us.yaml
@@ -1,0 +1,14 @@
+replicaCount: 2
+
+service:
+  name: document-store-api
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+              - us-east-1a

--- a/helm/document-store-api/templates/deployment.yaml
+++ b/helm/document-store-api/templates/deployment.yaml
@@ -20,25 +20,7 @@ spec:
         visualize: "true"
     spec:
       affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - {{ .Values.service.name }}
-            topologyKey: "kubernetes.io/hostname"
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - content-public-read
-              topologyKey: "kubernetes.io/hostname"
+{{ toYaml .Values.affinity | indent 8 }}
       containers:
       - name: {{ .Values.service.name }}
         image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"


### PR DESCRIPTION
# Description

## Why

To test if the latency is going to improve if we place `internal-content-api`, `enriched-content-read-api`, `content-public-read`, `document-store-api`, and `content-unroller` in the same AZ in US.

## Anything, in particular, you'd like to highlight to reviewers

_I left the affinity rules for EU just like they were._ 

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
