### PR TITLE
 Migrated to java 11 and updated dropwizard-swagger version #83 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:11.0.22
       - image: mongo:3.2.18
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:8u412-alpine3.16
+FROM amazoncorretto:11-alpine3.20
 
 ADD .git/ /.git/
 ADD . /document-store-api/
@@ -36,7 +36,7 @@ RUN apk --update add git maven curl \
   && apk del go git maven \
   && rm -rf /var/cache/apk/* /document-store-api/target* /root/.m2/* /tmp/*.apk
 
-FROM eclipse-temurin:8u345-b01-jre
+FROM eclipse-temurin:11-jre
 COPY --from=0 /document-store-api.jar /document-store-api.jar
 COPY --from=0 /config.yaml /config.yaml
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <target-jdk>1.8</target-jdk>
+        <target-jdk>11</target-jdk>
 
         <!-- Dependencies-->
-        <dw.version>2.0.18</dw.version>
-        <dw-swagger.version>2.0.0-1</dw-swagger.version>
+        <dw.version>2.0.19</dw.version>
+        <dw-swagger.version>2.0.12-1</dw-swagger.version>
         <advanced-dropwizard-healthcheck.version>4.14.2</advanced-dropwizard-healthcheck.version>
         <jax-rs-build-info-resource.version>1.3.1</jax-rs-build-info-resource.version>
         <jaxrs.error-handling.version>2.0.6</jaxrs.error-handling.version>
@@ -41,17 +41,17 @@
         <!-- Plugins-->
         <findbugs.version>2.5.2</findbugs.version>
         <surefire.reportplugin.version>2.22.2</surefire.reportplugin.version>
-        <maven-pmd-plugin.version>3.0.1</maven-pmd-plugin.version>
-        <jacoco-maven-plugin.version>0.7.4.201502262128</jacoco-maven-plugin.version>
-        <maven-jxr-plugin.version>2.3</maven-jxr-plugin.version>
-        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
-        <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
+        <maven-pmd-plugin.version>3.25.0</maven-pmd-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <maven-jxr-plugin.version>3.5.0</maven-jxr-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-shade-plugin.version>.</maven-shade-plugin.version>
-        <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
-        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
-        <ft-build-info-maven-plugin.version>1.0.2</ft-build-info-maven-plugin.version>
-        <maven-jar-plugin.version>2.3.2</maven-jar-plugin.version>
+        <ft-build-info-maven-plugin.version>1.1.0</ft-build-info-maven-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jersey2-jaxrs</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.2</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -281,7 +281,7 @@
                                     <version>3.6.0</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>1.8</version>
+                                    <version>11</version>
                                 </requireJavaVersion>
                                 <dependencyConvergence/>
                                 <banDuplicatePomDependencyVersions/>
@@ -308,6 +308,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
+                    <forkCount>0</forkCount>
                 </configuration>
                 <version>${surefire.reportplugin.version}</version>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
-                    <forkCount>0</forkCount>
                 </configuration>
                 <version>${surefire.reportplugin.version}</version>
             </plugin>


### PR DESCRIPTION
# Description

## What

Migrated to java 11 and updated dropwizard-swagger version. 

Currently, when document-store-api starts it’s application context it fails with ClassNotFoundExceptions related to drowpizard missing classes. At this moment the service is starting and it functions properly due to the fact we are not using the missing classes from dropwizard. Here is an opened snyk PR for version bump that might be the solution of the issue: ​
 

What we want to do as well is to bump the Java version of the service to 11. Currently we use 8 and upgrading the Java version will solve most of the snyk issues and warnings.

## Why

JIRA -> https://financialtimes.atlassian.net/browse/UPPSF-5589

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
